### PR TITLE
Setup auto portable releases

### DIFF
--- a/.github/workflows/portable_on_push.yml
+++ b/.github/workflows/portable_on_push.yml
@@ -1,0 +1,56 @@
+name: Build and release portable
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pyinstaller pyqt5 cryptography openai
+
+      - name: Create .env from secrets
+        run: |
+          echo AZURE_OPENAI_API_KEY=${{ secrets.AZURE_OPENAI_API_KEY }} >> .env
+          echo AZURE_OPENAI_ENDPOINT=${{ secrets.AZURE_OPENAI_ENDPOINT }} >> .env
+          echo AZURE_OPENAI_API_VERSION=${{ secrets.AZURE_OPENAI_API_VERSION }} >> .env
+
+      - name: Generate secure credentials
+        run: python setup_keys.py
+
+      - name: Build executable
+        shell: pwsh
+        run: |
+          pyinstaller --onefile --windowed `
+            --add-data ".env.secure;." `
+            --add-data ".key;." `
+            ai_adventure.py
+
+      - name: Package portable zip
+        shell: pwsh
+        run: |
+          Copy-Item .env.secure dist/
+          Copy-Item .key dist/
+          Compress-Archive -Path dist\* -DestinationPath ai_adventure_portable.zip
+
+      - name: Release portable build
+        uses: softprops/action-gh-release@v1
+        with:
+          name: Build ${{ github.run_number }}
+          tag_name: build-${{ github.run_number }}
+          files: ai_adventure_portable.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Readme.md
+++ b/Readme.md
@@ -9,3 +9,7 @@ Esta aplicaci\u00f3n genera una historia interactiva al estilo de las viejas ave
 3. Inici\u00e1 el juego con `python ai_adventure.py`.
 
 La interfaz est\u00e1 hecha con PyQt5 y requiere conexi\u00f3n a internet para comunicarse con OpenAI.
+
+## Descarga de builds portables
+
+Cada commit en `main` genera un zip `ai_adventure_portable.zip` en [Releases](../../releases). Descargalo, descompr\u00edmelo y ejecut\u00e1 `ai_adventure.exe` en Windows.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow that builds on push to `main`
- describe downloading portable builds in README

## Testing
- `python -m py_compile ai_adventure.py setup_keys.py`
- `pip install --quiet pyinstaller pyqt5 cryptography openai`
- `pyinstaller --onefile --noconsole ai_adventure.py --distpath dist_linux`
- `./dist_linux/ai_adventure --help` *(fails: Qt plugin xcb missing)*

------
https://chatgpt.com/codex/tasks/task_e_6870794a642c8328a7ee48c699ff2219